### PR TITLE
Adding a check to ensure we are only retrieving values that actually exist

### DIFF
--- a/src/Plugin/GraphQL/Fields/SolrField.php
+++ b/src/Plugin/GraphQL/Fields/SolrField.php
@@ -22,14 +22,22 @@ class SolrField extends FieldPluginBase {
    * {@inheritdoc}
    */
   public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+
     $derivative_id = $this->getDerivativeId();
-    if (is_array($value[$derivative_id])) {
-      foreach ($value[$derivative_id] as $value_item) {
-        yield $value_item;
+
+    // Not all documents have values for all fields so we need to check.
+    if (isset($value[$derivative_id])) {
+
+      // Checking if the value of this derivative is a list or single value so
+      // we can parse accordingly.
+      if (is_array($value[$derivative_id])) {
+        foreach ($value[$derivative_id] as $value_item) {
+          yield $value_item;
+        }
       }
-    }
-    else {
-      yield $value[$derivative_id];
+      else {
+        yield $value[$derivative_id];
+      }
     }
   }
 }


### PR DESCRIPTION
At the moment there is no check on $value[$derivative_id] which means that if you have an entity that doesn't have a field you specifed in the query you will get an invalid argument warning.