### PR TITLE
fix(SearchAPISearch): mark as secure

### DIFF
--- a/src/Plugin/GraphQL/Fields/SearchAPISearch.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISearch.php
@@ -11,6 +11,7 @@ use Drupal\search_api\Entity\Index;
  * A query field that wraps a Search API query.
  *
  * @GraphQLField(
+ *   secure = true,
  *   id = "search_api_search",
  *   type = "SearchAPIResult",
  *   name = "searchAPISearch",


### PR DESCRIPTION
Currently solrSearch can only be performed by admins. I have to ask about this but already fixed once the same issue in the metatag module : https://github.com/drupal-graphql/graphql-metatag/pull/4

so I assume the change is ok to make. But I need to better understand what "secure" marks..we have it in all the other fields.

This PR fixes the problem so that anonymous can also perform searches without any aditional permission required.