### PR TITLE
Added condition groups.

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -46,6 +46,17 @@ The structure of a condition can be broken down in:
 
 For more details about the options that can be used see the [Search parameters](search-parameters.md#conditions) page.
 
+### Condition Group
+The Condition Group input provides an object to encapsulate groups of conditions using a logical conjunction argument (e.g AND/OR).
+
+The structure of a condition group can be broken down in:
+
+* conditions - Conditions to be grouped (see Condition above).
+* groups - A group containing other condition groups.
+* conjunction - A logical operator for the group of conditions.
+
+For more details about the options that can be used see the [Search parameters](search-parameters.md#conditions) page.
+
 ### Facet
 The Facet input allows us to specify as arguments which facets we want returned in our query. The structure of the 
 facet input is:

--- a/docs/search-parameters.md
+++ b/docs/search-parameters.md
@@ -122,6 +122,54 @@ Returns the all results with type of course.
 }
 ```
 
+## Condition Groups
+Condition groups enhance the possibilities provided by conditions. It allows you to group sets of conditions and join them
+using logical conjunctions such as AND or OR.
+
+| Argument | Required | Type   | Values                                                                                                                  |
+|----------|----------|--------|-------------------------------------------------------------------------------------------------------------------------|
+| `conditions` | no       | `[ConditionInput]` | A set of conditions to be grouped. |
+| `groups`    | no      | `[ConditionGroupInput]` | A list of nested groups under this condition group.                                       |
+| `conjunction`    | no      | `QueryConjunction` | the conjunction to be used in this group. Values can be AND or OR.                                                      |                                    |
+
+### Example
+Returns the all results with type of course.
+
+```
+{
+  searchAPISearch(index_id: "index_name", 
+    
+    condition_group: {
+      conjunction: AND,
+      groups: [
+        {
+          conjunction: OR,
+          conditions: [
+            {operator: "=", name: "study_field", value: "Engineering"},
+            {operator: "=", name: "study_field", value: "Health"}
+          ]
+        }, 
+        {
+          conjunction: OR, 
+          conditions: [
+            {operator: "=", name: "administrative_area", value: "NSW"},
+            {operator: "=", name: "administrative_area", value: "VIC"}
+          ]
+        }
+      ]
+    }
+  ) {
+    
+    documents {
+      ... on IndexNameDoc {
+        title
+        body
+      }
+    }
+  }
+}
+```
+
 ## Sort
 Sorting parameters allow you to sort the result set.
 

--- a/src/Plugin/GraphQL/Fields/SearchAPISearch.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISearch.php
@@ -21,7 +21,7 @@ use Drupal\search_api\Entity\Index;
  *     "index_id" = "String!",
  *     "fulltext" = "FulltextInput",
  *     "language" = "[String]",
- *     "condition_group" = "ConditionFilterInput",
+ *     "condition_group" = "ConditionGroupInput",
  *     "conditions" = "[ConditionInput]",
  *     "range" = "RangeInput",
  *     "sort" = "SortInput",

--- a/src/Plugin/GraphQL/InputTypes/ConditionFilterInput.php
+++ b/src/Plugin/GraphQL/InputTypes/ConditionFilterInput.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\graphql_search_api\Plugin\GraphQL\InputTypes;
+
+use Drupal\graphql\Plugin\GraphQL\InputTypes\InputTypePluginBase;
+
+/**
+ * Condition input type.
+ *
+ * @GraphQLInputType(
+ *   id = "condition_filter_input",
+ *   name = "ConditionFilterInput",
+ *   fields = {
+ *     "conditions" = "[ConditionInput]",
+ *     "groups" = "[ConditionFilterInput]",
+ *     "operator" = "String",
+ *     "conjunction" = {
+ *       "type" = "QueryConjunction",
+ *       "default" = "AND"
+ *     }
+ *   }
+ * )
+ */
+class ConditionFilterInput extends InputTypePluginBase {
+
+}

--- a/src/Plugin/GraphQL/InputTypes/ConditionGroupInput.php
+++ b/src/Plugin/GraphQL/InputTypes/ConditionGroupInput.php
@@ -8,12 +8,11 @@ use Drupal\graphql\Plugin\GraphQL\InputTypes\InputTypePluginBase;
  * Condition input type.
  *
  * @GraphQLInputType(
- *   id = "condition_filter_input",
- *   name = "ConditionFilterInput",
+ *   id = "condition_group_input",
+ *   name = "ConditionGroupInput",
  *   fields = {
  *     "conditions" = "[ConditionInput]",
- *     "groups" = "[ConditionFilterInput]",
- *     "operator" = "String",
+ *     "groups" = "[ConditionGroupInput]",
  *     "conjunction" = {
  *       "type" = "QueryConjunction",
  *       "default" = "AND"
@@ -21,6 +20,6 @@ use Drupal\graphql\Plugin\GraphQL\InputTypes\InputTypePluginBase;
  *   }
  * )
  */
-class ConditionFilterInput extends InputTypePluginBase {
+class ConditionGroupInput extends InputTypePluginBase {
 
 }


### PR DESCRIPTION
Adding condition groups.

An example query would be as follows:

```
{
  searchAPISearch(index_id: "anabranch_connect_index", 
    
    condition_group: {
      conjunction: AND,
      groups: [
        {
          conjunction: OR,
          conditions: [
            {operator: "=", name: "study_field", value: "Engineering"},
            {operator: "=", name: "study_field", value: "Health"}
          ]
        }, 
        {
          conjunction: OR, 
          conditions: [
            {operator: "=", name: "administrative_area", value: "NSW"},
            {operator: "=", name: "administrative_area", value: "VIC"}
          ]
        }
      ]
    }
  ) {
    
    documents {
      ... on AnabranchConnectIndexDoc {
        title
        administrative_area
        study_field
      }
    }
  }
}
```